### PR TITLE
Add non-blocking tensor transfers with pin_memory option

### DIFF
--- a/preqtorch/replay.py
+++ b/preqtorch/replay.py
@@ -112,7 +112,7 @@ class ReplayBuffer(Replay):
 
 
 class ReplayingDataLoader:
-    def __init__(self, dataset, batch_size, replay: Replay, shuffle=True, collate_fn=None, warn_threshold=1):
+    def __init__(self, dataset, batch_size, replay: Replay, shuffle=True, collate_fn=None, warn_threshold=1, pin_memory=False):
         self.indexed_dataset = IndexedDataset(dataset)
         self.collate_fn = collate_fn or torch.utils.data._utils.collate.default_collate
         self.replay = replay
@@ -123,7 +123,8 @@ class ReplayingDataLoader:
             self.indexed_dataset,
             batch_size=batch_size,
             shuffle=shuffle,
-            collate_fn=_make_indexed_collate_fn(self.collate_fn)
+            collate_fn=_make_indexed_collate_fn(self.collate_fn),
+            pin_memory=pin_memory
         )
         self.iterator = iter(self.loader)
         self.samples_since_replay = 0

--- a/tests/test_device_moving.py
+++ b/tests/test_device_moving.py
@@ -109,7 +109,7 @@ def test_move_to_device_tensor():
     encoder.to('cuda')
 
     # Move tensor to device
-    cuda_tensor = encoder._move_to_device(cpu_tensor)
+    cuda_tensor = encoder._move_to_device(cpu_tensor, non_blocking=True)
 
     # Check if tensor is on CUDA
     assert cuda_tensor.device.type == 'cuda'
@@ -256,7 +256,7 @@ def test_move_to_cpu_tensor():
     assert cuda_tensor.device.type == 'cuda'
 
     # Move tensor to CPU
-    cpu_tensor = encoder._move_to_cpu(cuda_tensor)
+    cpu_tensor = encoder._move_to_cpu(cuda_tensor, non_blocking=True)
 
     # Check if tensor is on CPU
     assert cpu_tensor.device.type == 'cpu'


### PR DESCRIPTION
## Summary
- allow encoders to enable pinned-memory dataloaders
- move tensors with optional non-blocking transfers
- pass pin_memory through BlockEncoder and MIREncoder
- update ReplayingDataLoader for pin memory usage
- adjust device movement tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688059e41560832186eda260a79a2114