### PR TITLE
Fix mask defaults and add optional device/collate handling to encoders and dataloaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,17 @@ You may provide custom:
 
 directly to `encode(...)`, with the user owning dataloader construction.
 
+If you pass `collate_fn` to `encode(...)`, encoders will apply it when iterating the provided dataloaders.
+
 ### Dataset formatting
 
+Use one of the following sample schemas throughout your data pipeline:
+
+1. `(inputs, targets)`
+2. `(inputs, targets, shared_mask)`
+3. `(inputs, targets, output_mask, target_mask)`
+
+When masks are omitted, PreqTorch now defaults masks to the `targets` shape to align with code-length computation over predictions/targets.
 
 ### PrequentialDataLoader
 

--- a/preqtorch/batches.py
+++ b/preqtorch/batches.py
@@ -108,7 +108,7 @@ def prequential_collate(batch: Iterable):
     packed = default_collate(batch)
     if len(packed) == 2:
         inputs, targets = packed
-        output_mask = torch.ones_like(inputs, dtype=torch.bool)
+        output_mask = torch.ones_like(targets, dtype=torch.bool)
         target_mask = torch.ones_like(targets, dtype=torch.bool)
     elif len(packed) == 3:
         inputs, targets, shared_mask = packed

--- a/preqtorch/encoders.py
+++ b/preqtorch/encoders.py
@@ -4,7 +4,6 @@ import random
 import torch
 import torch.nn.functional as F
 from torch.func import functional_call
-from torch.utils.data import DataLoader
 
 from .batches import PrequentialBatch
 from .replay import ReplayBuffer, ReplayStreams, ReplayingDataLoader
@@ -66,13 +65,15 @@ class PrequentialEncoder:
             self._default_mask_cache[key] = mask
         return mask
 
-    def _normalize_batch(self, batch):
+    def _normalize_batch(self, batch, use_device_handling=True):
         if isinstance(batch, PrequentialBatch):
-            return batch.to(self.device, non_blocking=self.pin_memory)
+            if use_device_handling:
+                return batch.to(self.device, non_blocking=self.pin_memory)
+            return batch
         if isinstance(batch, (tuple, list)):
             if len(batch) == 2:
                 inputs, targets = batch
-                output_mask = self._get_default_mask(inputs)
+                output_mask = self._get_default_mask(targets)
                 target_mask = self._get_default_mask(targets)
             elif len(batch) == 3:
                 inputs, targets, mask = batch
@@ -82,7 +83,10 @@ class PrequentialEncoder:
                 inputs, targets, output_mask, target_mask = batch
             else:
                 raise ValueError("Unsupported batch format")
-            return PrequentialBatch(inputs, targets, output_mask, target_mask).to(self.device, non_blocking=self.pin_memory)
+            normalized = PrequentialBatch(inputs, targets, output_mask, target_mask)
+            if use_device_handling:
+                return normalized.to(self.device, non_blocking=self.pin_memory)
+            return normalized
         raise TypeError("Unsupported batch type")
 
 
@@ -101,37 +105,55 @@ class BlockEncoder(PrequentialEncoder):
         if len(train_dataloader) != len(eval_dataloaders):
             raise ValueError("train_dataloader and eval_dataloaders must have same length")
 
+        if collate_fn is not None:
+            def _with_collate(loader):
+                return loader if loader.collate_fn is collate_fn else torch.utils.data.DataLoader(
+                    dataset=loader.dataset,
+                    batch_size=loader.batch_size,
+                    shuffle=False,
+                    sampler=loader.sampler,
+                    num_workers=loader.num_workers,
+                    pin_memory=loader.pin_memory,
+                    drop_last=loader.drop_last,
+                    timeout=loader.timeout,
+                    worker_init_fn=loader.worker_init_fn,
+                    collate_fn=collate_fn,
+                )
+
+            train_dataloader = [_with_collate(loader) for loader in train_dataloader]
+            eval_dataloaders = [_with_collate(loader) for loader in eval_dataloaders]
+
         initial_weights = {name: value.detach().clone() for name, value in state.model.state_dict().items()}
 
         for i, (train_loader, eval_loader) in enumerate(zip(train_dataloader, eval_dataloaders)):
-            self.eval_code_length(state, eval_loader, encoding_fn)
+            self.eval_code_length(state, eval_loader, encoding_fn, use_device_handling=use_device_handling)
             if i == len(train_dataloader) - 1:
                 break
             state.model.load_state_dict(initial_weights)
-            self.train_until_patience(state, train_loader, patience, epochs)
+            self.train_until_patience(state, train_loader, patience, epochs, use_device_handling=use_device_handling)
 
         print(f"Performance for {set_name}: Prequential code length: {state.code_length}")
         return EncoderResult(state.model, state.code_length, state.history)
 
-    def calculate_code_length(self, model, batch, encoding_fn=None):
+    def calculate_code_length(self, model, batch, encoding_fn=None, use_device_handling=True):
         encoding_fn = encoding_fn or self._get_default_encoding_fn()
-        spec = self._normalize_batch(batch)
+        spec = self._normalize_batch(batch, use_device_handling=use_device_handling)
         outputs = model(spec.inputs)
         code_lengths = encoding_fn(outputs, spec.targets, spec.output_mask, spec.target_mask)
         return code_lengths, spec.inputs, spec.targets, spec.target_mask, spec.output_mask
 
-    def eval_code_length(self, state, dataloader, encoding_fn=None):
+    def eval_code_length(self, state, dataloader, encoding_fn=None, use_device_handling=True):
         encoding_fn = encoding_fn or state.encoding_fn or self._get_default_encoding_fn()
         model = state.model
         model.eval()
         with torch.inference_mode():
             for batch in dataloader:
-                code_lengths, _, _, _, _ = self.calculate_code_length(model, batch, encoding_fn)
+                code_lengths, _, _, _, _ = self.calculate_code_length(model, batch, encoding_fn, use_device_handling=use_device_handling)
                 value = code_lengths.sum().item()
                 state.code_length += value
                 state.history.append(value)
 
-    def train_until_patience(self, state, train_dataloader, patience, epochs):
+    def train_until_patience(self, state, train_dataloader, patience, epochs, use_device_handling=True):
         best_loss = float('inf')
         no_improvement = 0
         model = state.model
@@ -142,7 +164,7 @@ class BlockEncoder(PrequentialEncoder):
             for batch in train_dataloader:
                 encoding_fn = state.encoding_fn or self._get_default_encoding_fn()
                 optim.zero_grad()
-                code_lengths, _, _, _, _ = self.calculate_code_length(model, batch, encoding_fn)
+                code_lengths, _, _, _, _ = self.calculate_code_length(model, batch, encoding_fn, use_device_handling=use_device_handling)
                 loss = code_lengths.sum()
                 loss.backward()
                 optim.step()
@@ -179,7 +201,7 @@ class MIREncoder(PrequentialEncoder):
             pin_memory=pin_memory)
 
         for batch in replay_loader:
-            self.step(batch, replay_loader, state, alpha)
+            self.step(batch, replay_loader, state, alpha, use_device_handling=use_device_handling)
 
         model, code_length, history, ema_params, beta = self.finalize(state)
         return EncoderResult(model, code_length, history, ema_params=ema_params, beta=beta, replay=replay_loader.replay)
@@ -224,7 +246,7 @@ class MIREncoder(PrequentialEncoder):
         state = EncoderState(model, optim, beta, beta_optim, ema_params, trained_params, encoding_fn=encoding_fn)
         return state, replay_loader
 
-    def step(self, batch, replay_loader, state, alpha=0.1):
+    def step(self, batch, replay_loader, state, alpha=0.1, use_device_handling=True):
         model = state.model
         beta = state.beta
 
@@ -233,7 +255,7 @@ class MIREncoder(PrequentialEncoder):
         if use_beta:
             state.beta_optim.zero_grad()
 
-        code_lengths, _, _, _, _ = self.calculate_code_length(state, batch)
+        code_lengths, _, _, _, _ = self.calculate_code_length(state, batch, use_device_handling=use_device_handling)
         loss = code_lengths.sum()
         state.code_length += loss.detach()
         state.history.append(loss.detach())
@@ -243,7 +265,7 @@ class MIREncoder(PrequentialEncoder):
             state.beta_optim.zero_grad()
         if use_beta or state.ema_params is not None:
             state.optim.zero_grad()
-            code_lengths, _, _, _, _ = self.calculate_code_length(state, batch, False, False)
+            code_lengths, _, _, _, _ = self.calculate_code_length(state, batch, False, False, use_device_handling=use_device_handling)
             loss = code_lengths.sum()
             loss.backward()
         state.optim.step()
@@ -258,7 +280,7 @@ class MIREncoder(PrequentialEncoder):
 
         for _, replay_batch in replay_loader.sample_replay():
             state.optim.zero_grad()
-            code_lengths, _, _, _, _ = self.calculate_code_length(state, replay_batch, False, False)
+            code_lengths, _, _, _, _ = self.calculate_code_length(state, replay_batch, False, False, use_device_handling=use_device_handling)
             loss = code_lengths.sum()
             loss.backward()
             state.optim.step()
@@ -267,13 +289,13 @@ class MIREncoder(PrequentialEncoder):
                     for name, param in model.named_parameters():
                         state.ema_params[name] = state.ema_params[name] * (1 - alpha) + param * alpha
 
-    def calculate_code_length(self, state, batch, use_ema=True, use_beta=True):
+    def calculate_code_length(self, state, batch, use_ema=True, use_beta=True, use_device_handling=True):
         encoding_fn = state.encoding_fn or self._get_default_encoding_fn()
         model = state.model
         beta = state.beta
         ema_params = state.ema_params
 
-        spec = self._normalize_batch(batch)
+        spec = self._normalize_batch(batch, use_device_handling=use_device_handling)
         inputs = spec.inputs
         target = spec.targets
         output_mask = spec.output_mask

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -591,6 +591,7 @@ def test_default_encoding_fn():
         use_device_handling=False
     )
 
+    model, code_length, code_length_history = result.model, result.code_length, result.history
     print(f"Block Encoder (Default Encoding) - Code length: {code_length}.")
 
     # Test MIREncoder with default encoding function
@@ -622,6 +623,7 @@ def test_default_encoding_fn():
         use_ema=True
     )
 
+    model, code_length, code_length_history = result.model, result.code_length, result.history
     print(f"MIR Encoder (Default Encoding) - Code length: {code_length}.")
 
 def test_custom_encoding_fn_in_encode():
@@ -745,6 +747,7 @@ def test_mir_encoder_without_beta():
     )
 
     # Encode with MIREncoder (one-shot approach) without beta
+    loader = DataLoader(dataset, batch_size=32, shuffle=True, collate_fn=collate_fn_format3)
     result = mir_encoder.encode(
         dataloader=loader,
         set_name="Spanish Phonetic (MIR, Without Beta)",
@@ -758,6 +761,7 @@ def test_mir_encoder_without_beta():
         use_ema=True     # Keep EMA enabled
     )
 
+    model, code_length, code_length_history = result.model, result.code_length, result.history
     print(f"MIR Encoder (Without Beta) - Code length: {code_length}.")
 
 def test_mir_encoder_without_ema():
@@ -792,6 +796,7 @@ def test_mir_encoder_without_ema():
     )
 
     # Encode with MIREncoder (one-shot approach) without EMA
+    loader = DataLoader(dataset, batch_size=32, shuffle=True, collate_fn=collate_fn_format3)
     result = mir_encoder.encode(
         dataloader=loader,
         set_name="Spanish Phonetic (MIR, Without EMA)",
@@ -805,6 +810,7 @@ def test_mir_encoder_without_ema():
         use_ema=False    # Disable EMA
     )
 
+    model, code_length, code_length_history = result.model, result.code_length, result.history
     print(f"MIR Encoder (Without EMA) - Code length: {code_length}.")
 
 def test_mir_encoder_without_both():
@@ -839,6 +845,7 @@ def test_mir_encoder_without_both():
     )
 
     # Encode with MIREncoder (one-shot approach) without both beta and EMA
+    loader = DataLoader(dataset, batch_size=32, shuffle=True, collate_fn=collate_fn_format3)
     result = mir_encoder.encode(
         dataloader=loader,
         set_name="Spanish Phonetic (MIR, Without Both)",
@@ -852,6 +859,7 @@ def test_mir_encoder_without_both():
         use_ema=False    # Disable EMA
     )
 
+    model, code_length, code_length_history = result.model, result.code_length, result.history
     print(f"MIR Encoder (Without Both Beta and EMA) - Code length: {code_length}.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Ensure mask defaults align with targets (not inputs) so code-length computations are correct when masks are omitted.
- Allow callers to override `DataLoader.collate_fn` when encoding and to optionally disable automatic device movement for batches to support custom device handling or functional evaluation paths.
- Expose a `use_device_handling` toggle through encoder APIs so replay and block encoders can avoid implicit `.to(device)` on batches when necessary.

### Description

- Updated `README.md` to document collate behavior, accepted batch schemas, and default mask semantics when masks are omitted.
- Fixed default mask creation in `prequential_collate` to use `torch.ones_like(targets, dtype=torch.bool)` instead of using `inputs` for mask shape.
- Introduced a `use_device_handling` parameter in `PrequentialEncoder._normalize_batch`, `calculate_code_length`, `eval_code_length`, and training loops to optionally skip moving/ pinning batches to the encoder device.
- Added support in `BlockEncoder.encode` to accept a `collate_fn` and wrap incoming `DataLoader` instances to use the provided collate function without changing other loader semantics.
- Propagated `use_device_handling` through `MIREncoder` methods: `encode`, `step`, and `calculate_code_length`, and adjusted replay evaluation/training calls to honor the flag.
- Cleaned up an unused import and adjusted several function signatures to thread the new parameters.

### Testing

- Ran automated import and basic usage checks to validate module imports and the example usage in `README.md`, and observed no failures.
- Executed the repository's unit tests and existing test suite; all tests completed with no failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171d15ca0483219618638c09d7792c)