### PR TITLE
PrequentialEncoder: prefer model_class.device when selecting device

### DIFF
--- a/preqtorch/encoders.py
+++ b/preqtorch/encoders.py
@@ -30,7 +30,12 @@ class EncoderState:
 class PrequentialEncoder:
     def __init__(self, model_class: ModelClass, device=None, optimizer_fn=None, pin_memory=False):
         self.model_class = model_class
-        self.device = device if device is not None else ('cuda' if torch.cuda.is_available() else 'cpu')
+        if device is not None:
+            self.device = device
+        elif hasattr(model_class, "device"):
+            self.device = model_class.device
+        else:
+            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
         if hasattr(self.model_class, 'to'):
             self.model_class.to(self.device)
         self.optimizer_fn = optimizer_fn


### PR DESCRIPTION
### Motivation
- Ensure `PrequentialEncoder` selects a sensible default device by preferring a `device` attribute on the provided `model_class` before falling back to automatic CUDA detection.

### Description
- Update `PrequentialEncoder.__init__` to set `self.device` from the constructor `device` argument if provided, otherwise use `model_class.device` when present, and otherwise fallback to `'cuda'` if available or `'cpu'`.

### Testing
- No new tests were added; the existing test suite was executed and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1786054f9c8321a49563b1b4cdacab)