### PR TITLE
PrequentialDataLoader API: require PrequentialDataset, update README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When masks are omitted, PreqTorch now defaults masks to the `targets` shape to a
 
 `PrequentialDataset` and `PrequentialDataLoader` follow PyTorch conventions: dataset owns indexing logic; dataloader owns batching/shuffling/iteration.
 
-It accepts indexable sources at initialization and requires keyword arguments `inputs` and `targets`. Optional `masks` and `target_masks` are also supported.
+It accepts a mandatory `PrequentialDataset` at initialization. Optional dataloader arguments (e.g. `shuffle`, `batch_size`, `collate_fn`) are also supported.
 
 ```python
 from preqtorch import PrequentialDataset, PrequentialDataLoader
@@ -75,10 +75,7 @@ dataset = PrequentialDataset(
 )
 
 loader = PrequentialDataLoader(
-    inputs=my_inputs,
-    targets=my_targets,
-    masks=my_output_masks,
-    target_masks=my_target_masks,
+    dataset=dataset,
     shuffle=True,
 )
 ```

--- a/preqtorch/batches.py
+++ b/preqtorch/batches.py
@@ -94,10 +94,11 @@ class PrequentialDataset(Dataset):
 
 
 class PrequentialDataLoader(DataLoader):
-    """DataLoader specializing prequential batch schemas from indexable sources."""
+    """DataLoader specializing prequential batch schemas from PrequentialDataset."""
 
-    def __init__(self, *, inputs, targets, masks=None, target_masks=None, batch_size=1, shuffle=False, pin_memory=False, **kwargs):
-        dataset = PrequentialDataset(inputs, targets, masks=masks, target_masks=target_masks)
+    def __init__(self, dataset, *, batch_size=1, shuffle=False, pin_memory=False, **kwargs):
+        if not isinstance(dataset, PrequentialDataset):
+            raise TypeError("dataset must be a PrequentialDataset")
         collate_fn = kwargs.pop("collate_fn", None) or prequential_collate
         super().__init__(dataset=dataset, batch_size=batch_size, shuffle=shuffle, pin_memory=pin_memory, collate_fn=collate_fn, **kwargs)
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -5,7 +5,8 @@ def test_preq_loader_from_indexables():
     ys = [torch.tensor(i % 2) for i in range(5)]
     ms = [torch.tensor(True) for _ in range(5)]
 
-    loader = PrequentialDataLoader(inputs=xs, targets=ys, masks=ms, batch_size=2, shuffle=False)
+    dataset = PrequentialDataset(inputs=xs, targets=ys, masks=ms)
+    loader = PrequentialDataLoader(dataset, batch_size=2, shuffle=False)
     batch = next(iter(loader))
 
     assert hasattr(batch, "inputs")


### PR DESCRIPTION
### Motivation

- Simplify and standardize the data-loading API by moving dataset construction responsibility into a `PrequentialDataset` object passed to the loader.
- Clarify documentation and examples so users understand that the loader accepts a `PrequentialDataset` and that encoders default to the canonical `prequential_collate` when no `collate_fn` is provided.

### Description

- Change `PrequentialDataLoader.__init__` to accept a `dataset` argument and require it to be a `PrequentialDataset` by raising `TypeError` if not.
- Preserve default `collate_fn` behavior by using `kwargs.pop("collate_fn", None) or prequential_collate` when constructing the `DataLoader`.
- Update `README.md` examples and text to show initializing a `PrequentialDataset` and passing it into `PrequentialDataLoader` instead of providing indexable `inputs`/`targets` directly.
- Update unit tests in `tests/test_encoders.py` to construct a `PrequentialDataset` and initialize `PrequentialDataLoader` with the `dataset` argument.

### Testing

- Ran the modified unit test file with `pytest tests/test_encoders.py` and the tests passed.
- The updated tests validate the new loader construction and the presence of batch fields (`inputs`, `targets`, `output_mask`, `target_mask`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a178cfb33ec832188822bf340c0c1f7)